### PR TITLE
Use HTTPS for API requests

### DIFF
--- a/src/main/java/com/github/kennedyoliveira/pastebin4j/api/PasteBinApiUrls.java
+++ b/src/main/java/com/github/kennedyoliveira/pastebin4j/api/PasteBinApiUrls.java
@@ -10,28 +10,28 @@ class PasteBinApiUrls {
     /**
      * URL for interacting with all the options from the API.
      */
-    public static final String API_POST_URL = "http://pastebin.com/api/api_post.php";
+    public static final String API_POST_URL = "https://pastebin.com/api/api_post.php";
 
     /**
      * URL For fetching a user session key
      */
-    public static final String API_LOGIN_URL = "http://pastebin.com/api/api_login.php";
+    public static final String API_LOGIN_URL = "https://pastebin.com/api/api_login.php";
 
     /**
      * URL For fetching paste contents
      */
-    public static final String API_PASTE_CONTENT_URL = "http://pastebin.com/api/api_raw.php";
+    public static final String API_PASTE_CONTENT_URL = "https://pastebin.com/api/api_raw.php";
 
     /**
      * <p>This isn't for the API, but used to fetch raw paste contents.</p>
      * <p>Currently, it used a parameter {@code i} with the unique paste key to fetch the contents</p>
      */
-    public static final String PASTE_RAW_URL = "http://pastebin.com/raw.php";
+    public static final String PASTE_RAW_URL = "https://pastebin.com/raw.php";
 
     /**
      * <p>The URL base from the PasteBin Site.</p>
      */
-    public static final String PASTEBIN_URL = "http://pastebin.com/";
+    public static final String PASTEBIN_RESULT_URL = "http://pastebin.com/";
 
     private PasteBinApiUrls() {
     }

--- a/src/main/java/com/github/kennedyoliveira/pastebin4j/api/PasteUtil.java
+++ b/src/main/java/com/github/kennedyoliveira/pastebin4j/api/PasteUtil.java
@@ -2,7 +2,7 @@ package com.github.kennedyoliveira.pastebin4j.api;
 
 import org.jetbrains.annotations.Nullable;
 
-import static com.github.kennedyoliveira.pastebin4j.api.PasteBinApiUrls.PASTEBIN_URL;
+import static com.github.kennedyoliveira.pastebin4j.api.PasteBinApiUrls.PASTEBIN_RESULT_URL;
 
 /**
  * Utility class for extracting information from pastes
@@ -27,10 +27,10 @@ class PasteUtil {
         if (url == null)
             return null;
 
-        if (!url.contains(PASTEBIN_URL)) {
+        if (!url.contains(PASTEBIN_RESULT_URL)) {
             throw new IllegalArgumentException("Not a valid paste bin url!");
         }
 
-        return url.substring(url.indexOf(PASTEBIN_URL) + PASTEBIN_URL.length());
+        return url.substring(url.indexOf(PASTEBIN_RESULT_URL) + PASTEBIN_RESULT_URL.length());
     }
 }


### PR DESCRIPTION
This is an fix for kennedyoliveira/ultimate-pastebin-intellij-plugin#3. The goal is to use HTTPS whenever possible.